### PR TITLE
Squash character sheet bugs

### DIFF
--- a/css/qw.css
+++ b/css/qw.css
@@ -540,6 +540,9 @@
   overflow: visible;
 }
 
+.questworlds .sheet-body .abilities {
+  height: 100%;
+}
 .questworlds .sheet-body .abilities ol>li.item {
   padding-left: 2px;
 }

--- a/css/qw.css
+++ b/css/qw.css
@@ -251,11 +251,23 @@
   font-family: "Roboto", sans-serif;
 }
 
+.questworlds.sheet.actor .character {
+  max-height: 100%;
+}
+
+.questworlds .sheet-body {
+  min-height: 0;    /* override a flexbox default to allow shrinking smaller than content */
+}
+
+.questworlds .sheet-body .tab.main .grid {
+  overflow-y: auto;
+}
+
 .questworlds .sheet-header {
   -webkit-box-flex: 0;
   -ms-flex: 0 auto;
   flex: 0 auto;
-  overflow: hidden;
+  /* overflow: hidden; */
   display: -webkit-box;
   display: -ms-flexbox;
   display: flex;
@@ -519,9 +531,6 @@
   columns: 2;
   column-fill: auto;
 }
-.questworlds.actor .character .sheet-body .main .abilities {
-  padding-bottom: 40px;
-}
 .questworlds.item .sheet-body .abilities {
   margin-top: 0.6em;
 }
@@ -578,10 +587,8 @@
   padding-bottom: 8px;
   padding-left: 15px;
   padding-right: 29px;
-  position: absolute;
-  bottom: 0;
-  left: 0;
-  right: 0;
+  flex: 0;
+  margin: 0 -8px -8px;
 }
 .questworlds.actor.sheet .character .resources.footer {
   justify-content: space-between;
@@ -678,7 +685,7 @@
   text-shadow: 0 0 3px rgb(255 0 0 / 45%);
 }
 .questworlds.actor.sheet .character .main .resources .storypoints .story-points-pool {
-  font-size: 0.75rem
+  font-size: 0.75rem;
 }
 
 

--- a/css/qw.css
+++ b/css/qw.css
@@ -6,6 +6,11 @@
 @import "rune-settings.css";
 
 /* Global styles */
+:root {
+  /* --editor-shadow: inset 0 0 4px rgba(0 0 0 / 40%); */
+  --editor-shadow: inset 0 0 20px rgb(0 0 0 / 15%), inset 1px 1px 2px rgb(0 0 0 / 25%);
+}
+
 .window-app {
   font-family: "Roboto", sans-serif;
 }
@@ -483,12 +488,19 @@
 .questworlds.actor .sheet-body .tab,
 .questworlds.actor .sheet-body .tab.biography .grid,
 .questworlds.actor .sheet-body .tab.biography .grid section,
+.questworlds.actor .sheet-body .tab .editor,
 .questworlds.actor .sheet-body .tab .editor-content {
   height: 100%;
   padding-top: 0;
   padding-bottom: 0;
 }
-
+.questworlds.actor .sheet-body .tab .editor-content {
+  /* border: 1px solid #782e22; */
+  border: 1px solid rgba(120 46 34 / 65%);
+  border-radius: 6px;
+  background-color: rgba(255 255 255 / 40%);
+  box-shadow: var(--editor-shadow);
+}
 
 .questworlds.actor .npc .sheet-body .public,
 .questworlds.actor .npc .sheet-body .private {
@@ -499,7 +511,7 @@
   flex: 0;
 }
 .questworlds.actor .sheet-body .editor {
-  min-height: 32px;
+  min-height: 114px;
 }
 
 .questworlds.actor .sheet-body .tab.biography .grid {
@@ -517,7 +529,7 @@
 }
 
 .questworlds .tox .tox-editor-container {
-  background-color: rgba(255,255,255,.2);
+  background-color: rgba(255,255,255,.4);
   border-radius: 6px;
   border-style: solid;
   border-width: 1px;
@@ -525,6 +537,7 @@
 
 .questworlds .tox .tox-edit-area {
   padding: 0 8px;
+  box-shadow: var(--editor-shadow);
 }
 
 .questworlds .columns-2 {

--- a/css/qw.css
+++ b/css/qw.css
@@ -537,6 +537,8 @@
 
 .questworlds .tox .tox-edit-area {
   padding: 0 8px;
+}
+.questworlds .character .tox .tox-edit-area {
   box-shadow: var(--editor-shadow);
 }
 

--- a/module/sheets/actor-npc-sheet.mjs
+++ b/module/sheets/actor-npc-sheet.mjs
@@ -12,7 +12,7 @@ export class QuestWorldsActorNpcSheet extends ActorSheet {
       classes: ["questworlds", "sheet", "actor", "npc"],
       template: "systems/questworlds/templates/actor/actor-npc-sheet.html",
       width: 500,
-      height: 450
+      height: 580
     });
   }
 

--- a/templates/actor/actor-character-sheet.html
+++ b/templates/actor/actor-character-sheet.html
@@ -25,7 +25,7 @@
   <section class="sheet-body flex1">
 
     {{!-- Game Information Tab --}}
-    <div class="tab main" data-group="primary" data-tab="main">
+    <div class="tab main flexcol" data-group="primary" data-tab="main">
       <div class="grid grid-3col">
         <div class="grid-span-2">
           <section class="abilities columns-2">


### PR DESCRIPTION
- Fixes zero-height editors
- Editors on PC sheet indicate their location and size when inactive
- Higher background:text contrast on inactive PC sheet editors
- Better CSS for main PC sheet tab allows only scrolling abilities section, properly filling the left column first as new abilities added, eliminating bugs with visibility/overlap between footer and abilities
- Adds more room to NPC sheets, keeping cleaner UI

Closes #40 