### PR TITLE
Fix display bugs related to disabled rune settings

### DIFF
--- a/lang/en.json
+++ b/lang/en.json
@@ -326,6 +326,7 @@
             "storyPointsNameH": "What name will be used for Story Points on characters sheets and in the user interface.",
 
             "RuneMenu": {
+                "RuneSupportNotEnabled": "Rune support not enabled. To enable rune support, return to System Settings, check Enable Runes, and then cick Save Changes.",
                 "Builtins": {
                     "Header": "Configure Fonts for Built-in Runes",
                     "Hint1Instructions": "Upload one or more Rune fonts and enter the letters matching each Rune. Leave a blank to use a later font for that Rune. Fonts are ordered left to right. You can drag the headers to reorder fonts.",

--- a/module/documents/rune-settings-menu.mjs
+++ b/module/documents/rune-settings-menu.mjs
@@ -26,6 +26,11 @@ export class RuneFontsSettingsMenuClass extends FormApplication {
         const settingData = game.settings.get('questworlds', 'runeFontSettings');
         // const settingData = {};   // DEBUG: Clear settings. If paired with .set(), wipes stored settings too!
         
+        const useRunes = game.settings.get('questworlds','useRunes');
+        settingData.useRunes = useRunes;
+
+        if (!useRunes) return settingData;  // return early since we're only showing an error message
+
         /* set defaults in case of no settings data, or new defaults */
 
         if (!settingData.hasOwnProperty('customrunes')) settingData.customrunes = {};
@@ -60,7 +65,7 @@ export class RuneFontsSettingsMenuClass extends FormApplication {
 
         // iterate over settingData.runes to pad out the individual runes' .fonts arrays to
         // match the number of fonts known in settingData.fonts
-        const masterFontCount = settingData.fonts.length || 0; // behave well even if .fonts undefined
+        const masterFontCount = settingData?.fonts.length || 0; // behave well even if .fonts undefined
         if (masterFontCount > 0) {
             for (var runeProp in settingData.runes) {
                 let rune = settingData.runes[runeProp];
@@ -77,14 +82,17 @@ export class RuneFontsSettingsMenuClass extends FormApplication {
         // add convenience data to the context
         settingData.fontCount = masterFontCount;
 
-        // console.log(settingData);   // DEBUG: for inspecting data structure sent to form
         return settingData;
     }
 
     _updateObject(event, formData) {
         // console.log("_updateObject() fired")
+
+        // bail early if rune support not enabled
+        const useRunes = game.settings.get('questworlds','useRunes');
+        if (!useRunes) return;
+
         const data = expandObject(formData);
-        // console.log(data);
 
         /* handle fonts inputs */
 

--- a/module/sheets/item-sheet.mjs
+++ b/module/sheets/item-sheet.mjs
@@ -52,19 +52,25 @@ export class QuestWorldsItemSheet extends ItemSheet {
         // Add item type to the data.
         context.data.itemType = context.item.type;
 
+        // set up runes data
+
+        const useRunes = game.settings.get("questworlds","useRunes");
         // create a flat token:name object for the set of runes, sorted
-        const runeSettingList = Object.entries(game.settings.get('questworlds','runeFontSettings').runes).sort();
-        let runeSet = runeSettingList.reduce((set,e) => {
-            let [key, name] = [ e[0], e[1].name ];
-            set.push([key,name]);
-            return set; 
-        },[]);
-        runeSet.unshift(['','']);   // we need a "none" or blank option at the top
-        runeSet = Object.fromEntries(runeSet);  // convert array of entries to dictionary
-    
+        let runeSet;
+        let runeSettingList = game.settings.get('questworlds','runeFontSettings')?.runes;
+        if (useRunes && runeSettingList) {
+            runeSettingList = Object.entries(runeSettingList).sort();
+            runeSet = runeSettingList.reduce((set,e) => {
+                let [key, name] = [ e[0], e[1].name ];
+                set.push([key,name]);
+                return set; 
+            },[]);
+            runeSet.unshift(['','']);   // we need a "none" or blank option at the top
+            runeSet = Object.fromEntries(runeSet);  // convert array of entries to dictionary
+        }    
         // Add some game settings to the context
         context.settings = {
-            "useRunes": game.settings.get("questworlds","useRunes"),
+            "useRunes": useRunes,
             "sidekickName": game.settings.get("questworlds","sidekickName"),
             "keywordBreakout": game.settings.get("questworlds","keywordBreakout"),
             "runeSet": runeSet,

--- a/templates/forms/rune-fonts-settings-menu.html
+++ b/templates/forms/rune-fonts-settings-menu.html
@@ -1,5 +1,12 @@
 <form id="rune-settings" class="flexcol" autocomplete="off">
-
+    {{#unless useRunes}}
+    <div style="margin-top: 1em; text-align: center;">
+        {{localize 'QUESTWORLDS.SETTINGS.RuneMenu.RuneSupportNotEnabled'}}
+        <div style="width: 100%; text-align: center; margin-top:1em; font-size: 2em;">
+            &#x2619;
+        </div>
+    </div>
+    {{else}}
     <h2>{{localize 'QUESTWORLDS.SETTINGS.RuneMenu.Builtins.Header'}}</h2>
 
     <p class="notes">
@@ -91,6 +98,8 @@
             {{/each}}
         </tbody>
     </table>
+
+    {{/unless}} {{!-- unless useRunes --}}
 
     {{!--
     <h2>Custom Runes</h2>


### PR DESCRIPTION
- Fix rune-related CSS not being generated when rune fonts configured before enabling rune support: replace the rune settings menu content with an error and instructions if rune support not enabled. (Closes #41)
- Fix item sheets not displaying when rune support disabled, caused by error during data preparation